### PR TITLE
fix: custom env vars definition

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,7 +12,10 @@
     "password": "DATABASE_PASSWORD",
     "host": "DATABASE_HOST",
     "port": "DATABASE_PORT",
-    "logging": "DATABASE_LOGGING",
+    "logging": {
+      "__name": "DATABASE_LOGGING",
+      "__format": "boolean"
+    },
     "schema": "DATABASE_SCHEMA"
   },
   "client": {


### PR DESCRIPTION
## Description

[node-config](https://github.com/node-config/node-config) need some extra config for boolean values like `DATABASE_LOGGING`:

```
"logging": {
  "__name": "DATABASE_LOGGING",
  "__format": "boolean"
},
```

Otherwise, `config.get` will return always a string.

## Resources:

- https://github.com/node-config/node-config/wiki/Environment-Variables#custom-environment-variables

- https://github.com/node-config/node-config/blob/8681019099f43eb4762d5cecf2f42ab9e99f3f5e/test/config/custom-environment-variables.json#L13